### PR TITLE
Fix Load ng-currency from the wrong location

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "Luis Aguirre <luis@alaguirre.com>"
   ],
   "description": "Directive that works in conjunction with currency filter.",
-  "main": "ng-currency.js",
+  "main": "dist/ng-currency.js",
   "keywords": [
     "currency",
     "directive",


### PR DESCRIPTION
Previously, ng-currency.js are loaded from / while the actual file location is in /dist
