### PR TITLE
Upgrade to leverage Angular 1.3.X $validators and tweak model update behavior when view value is not valid

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,9 +21,12 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.2.16"
+    "angular": "~1.3.4"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.16"
+    "angular-mocks": "~1.3.4"
+  },
+  "resolutions": {
+    "angular": "~1.3.4"
   }
 }

--- a/src/ng-currency.js
+++ b/src/ng-currency.js
@@ -70,25 +70,25 @@ angular.module('ng-currency', [])
                     return $filter('currency')(value, currencySymbol());
                 });
 
-                scope.$watch(function () {
-                    return ngModel.$modelValue
-                }, function (newValue, oldValue) {
-                    runValidations(newValue);
-                })
-
-                function runValidations(cVal) {
+                ngModel.$validators.min = function(cVal) {
                     if (!scope.ngRequired && isNaN(cVal)) {
-                        return
+                        return true;
                     }
-                    if (scope.min) {
-                        var min = parseFloat(scope.min)
-                        ngModel.$setValidity('min', cVal >= min)
+                    if(scope.min) {
+                        return cVal >= parseFloat(scope.min);
                     }
-                    if (scope.max) {
-                        var max = parseFloat(scope.max)
-                        ngModel.$setValidity('max', cVal <= max)
+                    return true;
+                };
+
+                ngModel.$validators.max = function(cVal) {
+                    if (!scope.ngRequired && isNaN(cVal)) {
+                        return true;
                     }
-                }
+                    if(scope.max) {
+                        return cVal <= parseFloat(scope.max);
+                    }
+                    return true;
+                };
             }
         }
     }]);

--- a/test/ng-currency.test.js
+++ b/test/ng-currency.test.js
@@ -1,7 +1,8 @@
 'use strict';
 
 describe('ngCurrency directive tests', function() {
-    var elem, scope;
+    var elem,
+        scope;
 
     beforeEach(module('ng-currency'));
     beforeEach(inject(function($rootScope, $compile) {
@@ -38,7 +39,7 @@ describe('ngCurrency directive tests', function() {
   );
 
   describe("when currency-symbol is declared", function() {
-    beforeEach(inject(function($rootScope, $compile) {
+    beforeEach(inject(function($rootScope) {
       scope = $rootScope.$new();
       elem = angular.element("<input ng-model='testModel' name='ngtest' type='text' ng-currency currency-symbol='¥'>");
     }));
@@ -50,10 +51,10 @@ describe('ngCurrency directive tests', function() {
         scope.$digest();
         expect(elem.val()).toEqual("¥123.45");
       })
-    )
+    );
 
     describe("when currency-symbol declared is empty", function() {
-      beforeEach(inject(function($rootScope, $compile) {
+      beforeEach(inject(function($rootScope) {
         scope = $rootScope.$new();
         elem = angular.element("<input ng-model='testModel' name='ngtest' type='text' ng-currency currency-symbol=''>");
       }));
@@ -65,7 +66,7 @@ describe('ngCurrency directive tests', function() {
           scope.$digest();
           expect(elem.val()).toEqual("123.45");
         })
-      )
+      );
     });
   });
 
@@ -130,40 +131,72 @@ describe('ngCurrency directive tests', function() {
       elem.hasClass('ng-invalid-required')
      })
   );
-  it('should set -0 value from string - ',
-    inject(function($rootScope,$compile) {
-      scope.testModel = 0;
-      elem = $compile(elem)(scope);
-      elem.val("-");
-      elem.triggerHandler('input');
-      expect(scope.testModel).toEqual(-0);
-     })
-  );
-  it('should set -0 value from string \'- \' ',
-    inject(function($rootScope,$compile) {
-      scope.testModel = 0;
-      elem = $compile(elem)(scope);
-      elem.val("- ");
-      elem.triggerHandler('input');
-      expect(scope.testModel).toEqual(-0);
-     })
-  );
-  it('should set -1.11 value from string -1.11',
-    inject(function($rootScope,$compile) {
-      scope.testModel = 0;
-      elem = $compile(elem)(scope);
-      elem.val("-1.11");
-      elem.triggerHandler('input');
-      expect(scope.testModel).toEqual(-1.11);
-     })
-  );
-  it('should set -1.11 value from string $ -1.11',
-    inject(function($rootScope,$compile) {
-      scope.testModel = 0;
-      elem = $compile(elem)(scope);
-      elem.val("$ -1.11");
-      elem.triggerHandler('input');
-      expect(scope.testModel).toEqual(-1.11);
-     })
-  );
+
+  describe('model value should be undefined when view value does not pass validation', function() {
+
+    it('should not set 0 value from string 0 when required min is not met',
+      inject(function($rootScope,$compile) {
+        scope.testModel = 0;
+        elem = $compile(elem)(scope);
+        elem.val("0");
+        elem.triggerHandler('input');
+        expect(scope.testModel).toBeUndefined();
+      })
+    );
+
+    it('should not set 9999991 value from string 9999991 when required max is not met',
+      inject(function($rootScope,$compile) {
+        scope.testModel = 0;
+        elem = $compile(elem)(scope);
+        elem.val("0");
+        elem.triggerHandler('input');
+        expect(scope.testModel).toBeUndefined();
+      })
+    );
+
+  });
+
+  describe('when the min is set to zero or lower', function() {
+    beforeEach(function() {
+      elem = angular.element("<input ng-model='testModel' name='ngtest' type='text' min='-2' max='999999' ng-required='true' ng-currency>");
+    });
+
+    it('should set -0 value from string - ',
+      inject(function($rootScope,$compile) {
+        scope.testModel = 0;
+        elem = $compile(elem)(scope);
+        elem.val("-");
+        elem.triggerHandler('input');
+        expect(scope.testModel).toBe(-0);
+      })
+    );
+    it('should set -0 value from string \'- \' ',
+      inject(function($rootScope,$compile) {
+        scope.testModel = 0;
+        elem = $compile(elem)(scope);
+        elem.val("- ");
+        elem.triggerHandler('input');
+        expect(scope.testModel).toBe(-0);
+      })
+    );
+    it('should set -1.11 value from string -1.11',
+      inject(function($rootScope,$compile) {
+        scope.testModel = 0;
+        elem = $compile(elem)(scope);
+        elem.val("-1.11");
+        elem.triggerHandler('input');
+        expect(scope.testModel).toBe(-1.11);
+      })
+    );
+    it('should set -1.11 value from string $ -1.11',
+      inject(function($rootScope,$compile) {
+        scope.testModel = 0;
+        elem = $compile(elem)(scope);
+        elem.val("$ -1.11");
+        elem.triggerHandler('input');
+        expect(scope.testModel).toBe(-1.11);
+      })
+    );
+  });
+
 });


### PR DESCRIPTION
So while this directive works fine in Angular 1.3.X, I feel that it should take advantage of the new `$validators` pipeline available on the `NgModelController`.

This PR:
- Upgrades Angular dependencies to ~1.3.4
- Updates min/max validation to use `$validators`
- Changes the expected behavior, such that the model value is invalidated and set to `undefined` when the view value does not pass validation

A couple of thoughts: 
- Most controversial change in this PR is probably the change in behavior around model value updates on invalid view value changes
- Do people even want this and should there be a separate branch for 1.3.X version of the plugin?
