### PR TITLE
Fix min/max to accept 0 as a valid value

### DIFF
--- a/src/ng-currency.js
+++ b/src/ng-currency.js
@@ -80,11 +80,11 @@ angular.module('ng-currency', [])
                     if (isNaN(cVal)) {
                         return
                     }
-                    if (scope.min) {
+                    if (scope.min || scope.min === 0) {
                         var min = parseFloat(scope.min)
                         ngModel.$setValidity('min', cVal >= min)
                     }
-                    if (scope.max) {
+                    if (scope.max || scope.max === 0) {
                         var max = parseFloat(scope.max)
                         ngModel.$setValidity('max', cVal <= max)
                     }


### PR DESCRIPTION
0 was previously failing falsy check. The case that prompted this fix
was trying to set min="0" to disallow negative values, to no effect.