### PR TITLE
V0.8.x: Adding ng-currency false option, and using $filter.currency's fraction parameter

### DIFF
--- a/src/ng-currency.js
+++ b/src/ng-currency.js
@@ -17,6 +17,7 @@ angular.module('ng-currency', [])
                 ngRequired: '=ngRequired'
             },
             link: function (scope, element, attrs, ngModel) {
+                if (attrs.ngCurrency === 'false') return;
 
                 function decimalRex(dChar) {
                     return RegExp("\\d|\\-|\\" + dChar, 'g');

--- a/src/ng-currency.js
+++ b/src/ng-currency.js
@@ -14,7 +14,8 @@ angular.module('ng-currency', [])
                 min: '=min',
                 max: '=max',
                 currencySymbol: '@',
-                ngRequired: '=ngRequired'
+                ngRequired: '=ngRequired',
+                fraction: '=fraction'
             },
             link: function (scope, element, attrs, ngModel) {
                 if (attrs.ngCurrency === 'false') return;
@@ -82,7 +83,7 @@ angular.module('ng-currency', [])
                 });
 
                 ngModel.$formatters.unshift(function (value) {
-                    return $filter('currency')(value, currencySymbol());
+                    return $filter('currency')(value, currencySymbol(), scope.fraction);
                 });
 
                 ngModel.$validators.min = function(cVal) {
@@ -102,6 +103,14 @@ angular.module('ng-currency', [])
                     if(scope.max) {
                         return cVal <= parseFloat(scope.max);
                     }
+                    return true;
+                };
+
+                ngModel.$validators.fraction = function(cVal) {
+                    if (!!cVal && isNaN(cVal)) {
+                        return false;
+                    }
+
                     return true;
                 };
             }


### PR DESCRIPTION
This request contains two features:

* Gives ng-currency the possibility of returning false so it can be turned off for fields that not need the currency value. I'm sure there's a better way to do this, but this works and it's simple.

``
ng-currency="{{isCurrency}}"
``

* Adding an optional fraction value to take advantage of the currency filter's third param. It works like ``min`` and ``max``. The default remains 2 decimal places.

``
<input type="text" ng-currency min="0" fraction="0"
``