### PR TITLE
Allow inputs to start with separaters, e.g '.'

### DIFF
--- a/src/ng-currency.js
+++ b/src/ng-currency.js
@@ -55,7 +55,7 @@ angular.module('ng-currency', [])
 
                 ngModel.$parsers.push(function (viewValue) {
                     var cVal = clearValue(viewValue);
-                    return parseFloat(cVal);
+                    return (cVal == $locale.NUMBER_FORMATS.DECIMAL_SEP) ? $locale.NUMBER_FORMATS.DECIMAL_SEP : parseFloat(cVal);
                 });
 
                 element.on("blur", function () {


### PR DESCRIPTION
0.8.6 doesn't allow you type a '.' input an empty input, for example to quickly type '.5' for 50 cents. This fixes this by parsing the input as a string if it matches a single decimal separator.