### PR TITLE
Add fraction-size option to directive to round cents.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components
 test/coverage/
+node_modules

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ angular.module('myApp', ['ng-currency']);
 <input type="text" ng-model="yourModel" ng-currency currency-symbol="¥" />
 ```
 
++ To round the display to the nearest dollar, you can use the "fraction-size" option from the [currency filter](https://docs.angularjs.org/api/ng/filter/currency)
+
+>
+``` html
+<input type="text" ng-model="yourModel" ng-currency fraction-size="0" />
+```
+
 ## Contributing
 
 Please submit all pull requests the against master branch. If your unit test contains JavaScript patches or features, you should include relevant unit tests. Thanks!

--- a/bower.json
+++ b/bower.json
@@ -21,9 +21,9 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.2.16"
+    "angular": "~1.3"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.16"
+    "angular-mocks": "~1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "karma start test/karma.config.js --single-run",
+    "test-watch": "karma start test/karma.config.js"
   },
   "repository": {
     "type": "git",
@@ -23,5 +24,11 @@
   "bugs": {
     "url": "https://github.com/aguirrel/ng-currency/issues"
   },
-  "homepage": "https://github.com/aguirrel/ng-currency#readme"
+  "homepage": "https://github.com/aguirrel/ng-currency#readme",
+  "devDependencies": {
+    "karma": "^0.12.37",
+    "karma-chrome-launcher": "^0.2.0",
+    "karma-coverage": "^0.4.2",
+    "karma-jasmine": "^0.3.5"
+  }
 }

--- a/src/ng-currency.js
+++ b/src/ng-currency.js
@@ -7,13 +7,14 @@
  */
 
 angular.module('ng-currency', [])
-    .directive('ngCurrency', ['$filter', '$locale', function ($filter, $locale) {
+    .directive('ngCurrency', ['currencyFilter', '$locale', function (currencyFilter, $locale) {
         return {
             require: 'ngModel',
             scope: {
                 min: '=min',
                 max: '=max',
                 currencySymbol: '@',
+                fractionSize: '=',
                 ngRequired: '=ngRequired'
             },
             link: function (scope, element, attrs, ngModel) {
@@ -59,11 +60,11 @@ angular.module('ng-currency', [])
                 });
 
                 element.on("blur", function () {
-                    element.val($filter('currency')(ngModel.$modelValue, currencySymbol()));
+                    element.val(currencyFilter(ngModel.$modelValue, currencySymbol(), scope.fractionSize));
                 });
 
                 ngModel.$formatters.unshift(function (value) {
-                    return $filter('currency')(value, currencySymbol());
+                    return currencyFilter(value, currencySymbol(), scope.fractionSize);
                 });
 
                 scope.$watch(function () {

--- a/test/ng-currency.test.js
+++ b/test/ng-currency.test.js
@@ -69,6 +69,39 @@ describe('ngCurrency directive tests', function() {
     });
   });
 
+  describe("when fraction-size is declared", function() {
+    beforeEach(inject(function($rootScope, $compile) {
+      scope = $rootScope.$new();
+      elem = angular.element("<input ng-model='testModel' name='ngtest' type='text' ng-currency fraction-size='fractionSize'>");
+    }));
+
+    it('should display a currency with cents rounded to the fractionSize',
+      inject(function($rootScope,$compile) {
+        scope.testModel = 123.85;
+        scope.fractionSize = 0;
+        elem = $compile(elem)(scope);
+        scope.$digest();
+        elem.triggerHandler('blur');
+        expect(elem.val()).toEqual("$124");
+
+        scope.fractionSize = 1;
+        scope.$digest();
+        elem.triggerHandler('blur');
+        expect(elem.val()).toEqual("$123.9");
+      })
+    )
+    it('should not set ngModel to a rounded value if they enter more decimal places than fractionSize',
+      inject(function($rootScope,$compile) {
+        scope.testModel = 0;
+        scope.fractionSize = 0;
+        elem = $compile(elem)(scope);
+        elem.val("123.99");
+        elem.triggerHandler('input');
+        expect(scope.testModel).toEqual(123.99);
+       })
+    );
+  });
+
   it('should set ngModel to 123.45 from string $11.11 as locale currency',
     inject(function($rootScope,$compile) {
       scope.testModel = 0;
@@ -130,22 +163,22 @@ describe('ngCurrency directive tests', function() {
       elem.hasClass('ng-invalid-required')
      })
   );
-  it('should set -0 value from string - ',
+  it('should set 0 value from string - ',
     inject(function($rootScope,$compile) {
       scope.testModel = 0;
       elem = $compile(elem)(scope);
       elem.val("-");
       elem.triggerHandler('input');
-      expect(scope.testModel).toEqual(-0);
+      expect(scope.testModel).toEqual(0);
      })
   );
-  it('should set -0 value from string \'- \' ',
+  it('should set 0 value from string \'- \' ',
     inject(function($rootScope,$compile) {
       scope.testModel = 0;
       elem = $compile(elem)(scope);
       elem.val("- ");
       elem.triggerHandler('input');
-      expect(scope.testModel).toEqual(-0);
+      expect(scope.testModel).toEqual(0);
      })
   );
   it('should set -1.11 value from string -1.11',


### PR DESCRIPTION
Parts:

- Add npm dev-dependencies and npm test command
- Replace $filter with currencyFilter directly
- Upgrade angular to 1.3 for currencyFilter fractionSize param.

I changed some tests related to -0 conversion.  I belive currencyFilter
changed its implementation in angular 1.3, and that these tests were to
document the behavior but weren't actually a feature people relied upon.

https://github.com/angular/angular.js/blob/master/CHANGELOG.md#130-superluminal-nudge-2014-10-13

I am not totally sure if the rounding should go in both directions.
E.g. if the user enters '1.99' it is currently storing on the model
as 1.99, but displayed as 2 when fraction-size is 0.