### PR TITLE
Make sure we work with a float value on focus

### DIFF
--- a/src/ng-currency.js
+++ b/src/ng-currency.js
@@ -160,7 +160,7 @@ angular.module('ng-currency', [])
                     }
                     else
                     {
-                        viewValue = viewValue.toFixed(scope.fraction);
+                        viewValue = parseFloat(viewValue).toFixed(scope.fraction);
                     }
                     ngModel.$setViewValue(viewValue);
                     ngModel.$render();


### PR DESCRIPTION
This PR fixes a `Uncaught TypeError: myValue.toFixed is not a function` error when not strictly working with a float value. Please see [this plunkr](https://plnkr.co/edit/pAQYaePU0X5G3TD0spWJ) for what's going wrong. Open up developer tools and focus in on the input. Uncaught TypeError should appear.