### PR TITLE
Allow using newer versions of Angular.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-currency",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "authors": [
     "Luis Aguirre <luis@alaguirre.com>"
   ],
@@ -21,7 +21,7 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.3.4"
+    "angular": ">=1.3.4"
   },
   "devDependencies": {
     "angular-mocks": "~1.3.4"


### PR DESCRIPTION
`ng-currency` causes Bower to throw dependency conflicts when users have newer versions of Angular installed, such as Angular 1.4.5. An easy fix for this is to allow versions of Angular greater than or equal to the minimum requirement.