### PR TITLE
when editing the input the number have the localize number format

### DIFF
--- a/dist/ng-currency.js
+++ b/dist/ng-currency.js
@@ -167,7 +167,7 @@ angular.module('ng-currency', [])
                     {
                         viewValue = parseFloat(viewValue).toFixed(scope.fraction);
                     }
-                    ngModel.$setViewValue(viewValue);
+                    ngModel.$setViewValue(Number(viewValue).toLocaleString($locale.id));
                     ngModel.$render();
                 });
             }

--- a/src/ng-currency.js
+++ b/src/ng-currency.js
@@ -167,7 +167,7 @@ angular.module('ng-currency', [])
                     {
                         viewValue = parseFloat(viewValue).toFixed(scope.fraction);
                     }
-                    ngModel.$setViewValue(viewValue);
+                    ngModel.$setViewValue(Number(viewValue).toLocaleString($locale.id));
                     ngModel.$render();
                 });
             }


### PR DESCRIPTION
Hi aguirrel,

While working with your directive on de-De (German) local,
I face a weird behavior, when I want to edit the value, I get the International number format.
for example:
on blur I see : 1.000.000,00 (million in German format)
on focus I see : 1,000,000.00 (International format)

In this pull Request I set the $setViewValue to the $local format :)

Please approve this PR, and PR https://github.com/aguirrel/ng-currency/pull/83 so I can delete my modified directive and use yours :)

Thanks and have a great weekend!