### PR TITLE
fix(validators): fix invalid values causing the field to get blanked out

### DIFF
--- a/src/ng-currency.directive.js
+++ b/src/ng-currency.directive.js
@@ -12,7 +12,7 @@ export default function ngCurrency($filter, $locale) {
         if (active) {
           reformat();
         } else {
-          controller.$viewValue = controller.$modelValue;
+          controller.$viewValue = controller.$$rawModelValue;
           controller.$render();
         }
       });
@@ -82,7 +82,7 @@ export default function ngCurrency($filter, $locale) {
 
       function reformat() {
         if (active) {
-          let value = controller.$modelValue;
+          let value = controller.$$rawModelValue;
           for (let i = controller.$formatters.length - 1; i >= 0; i--) {
             value = controller.$formatters[i](value);
           }
@@ -121,7 +121,8 @@ export default function ngCurrency($filter, $locale) {
 
       element.bind('focus', () => {
         if (active) {
-          const value = [undefined, null, ''].indexOf(controller.$modelValue) === -1 ? $filter('number')(controller.$modelValue, fraction).replace($locale.NUMBER_FORMATS.GROUP_SEP, '') : controller.$modelValue;
+          const groupRegex = new RegExp(`\\${$locale.NUMBER_FORMATS.GROUP_SEP}`, 'g');
+          const value = [undefined, null, ''].indexOf(controller.$$rawModelValue) === -1 ? $filter('number')(controller.$$rawModelValue, fraction).replace(groupRegex, '') : controller.$$rawModelValue;
           if (controller.$viewValue !== value) {
             controller.$viewValue = value;
             controller.$render();

--- a/test/ng-currency/ng-currency.directive.spec.js
+++ b/test/ng-currency/ng-currency.directive.spec.js
@@ -146,14 +146,14 @@ describe('ngCurrency directive tests', () => {
       it('should support locales with "," as the decimal separator and "." as the group separator', () => {
         $locale.NUMBER_FORMATS.DECIMAL_SEP = ',';
         $locale.NUMBER_FORMATS.GROUP_SEP = '.';
-        element.val('$0,50');
+        element.val('$1.000,50');
         element.triggerHandler('input');
         element.triggerHandler('blur');
-        expect(scope.value).toEqual(0.5);
-        expect(element.val()).toEqual('$0,50');
+        expect(scope.value).toEqual(1000.5);
+        expect(element.val()).toEqual('$1.000,50');
         element.triggerHandler('focus');
-        expect(scope.value).toEqual(0.5);
-        expect(element.val()).toEqual('0,50');
+        expect(scope.value).toEqual(1000.5);
+        expect(element.val()).toEqual('1000,50');
       });
     });
 
@@ -349,6 +349,16 @@ describe('ngCurrency directive tests', () => {
         scope.$digest();
         expect(element.val()).toEqual('a');
       });
+
+      it('should display the real value when disabled with an invalid value', () => {
+        scope.value = 0.01;
+        scope.min = 1;
+        scope.$digest();
+        expect(element.val()).toEqual('$0.01');
+        scope.active = false;
+        scope.$digest();
+        expect(element.val()).toEqual('0.01');
+      });
     });
 
     describe('Currency Symbol', () => {
@@ -402,6 +412,10 @@ describe('ngCurrency directive tests', () => {
           scope.max = 1000000;
           scope.$digest();
           expect(element.hasClass('ng-invalid-max')).toBeTruthy();
+          expect(element.val()).toEqual('$1,999,999.00');
+          element.triggerHandler('focus');
+          expect(element.val()).toEqual('1999999.00');
+          element.triggerHandler('blur');
           expect(element.val()).toEqual('$1,999,999.00');
         });
 
@@ -509,6 +523,10 @@ describe('ngCurrency directive tests', () => {
           scope.min = 1;
           scope.$digest();
           expect(element.hasClass('ng-invalid-min')).toBeTruthy();
+          expect(element.val()).toEqual('$0.01');
+          element.triggerHandler('focus');
+          expect(element.val()).toEqual('0.01');
+          element.triggerHandler('blur');
           expect(element.val()).toEqual('$0.01');
         });
 


### PR DESCRIPTION
Invalid values were causing the field to become blank when focused or blurred.
Focusing the field will no longer leave behind extra group separators.

This closes #110