### PR TITLE
Added Configuration Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,21 @@ angular.module('myApp', ['ng-currency']);
 <input type="text" ng-currency min="0" hard-cap="true" />
 ```
 
+## Configuration
+If you always have the same properties you can define them in the config:
+
+```javascript
+angular
+  .module('my-app', ['ng-currency'])
+  .config(function(ngCurrencySettingsProvider){ 
+	ngCurrencySettingsProvider.setDefaultCurrencySymbol('CHF ');
+	ngCurrencySettingsProvider.setDefaultFraction(0);
+	ngCurrencySettingsProvider.setDefaultHardCap(true);
+	ngCurrencySettingsProvider.setDefaultMin(100);
+	ngCurrencySettingsProvider.setDefaultMax(200);
+  });
+```
+
 ## Authors
 
 **Luis Aguirre**

--- a/src/ng-currency-settings.provider.js
+++ b/src/ng-currency-settings.provider.js
@@ -1,0 +1,31 @@
+export default function ngCurrencySettings() {
+  this.config = {
+    defaultFraction: 2,
+    defaultHardCap: false,
+    defaultMin: undefined,
+    defaultMax: undefined,
+    defaultCurrencySymbol: undefined
+  };
+
+  this.setDefaultCurrencySymbol = defaultCurrencySymbol => {
+    this.config.defaultCurrencySymbol = defaultCurrencySymbol;
+  };
+
+  this.setDefaultFraction = defaultFraction => {
+    this.config.defaultFraction = defaultFraction;
+  };
+
+  this.setDefaultHardCap = defaultHardCap => {
+    this.config.defaultHardCap = defaultHardCap;
+  };
+
+  this.setDefaultMin = defaultMin => {
+    this.config.defaultMin = defaultMin;
+  };
+
+  this.setDefaultMax = defaultMax => {
+    this.config.defaultMax = defaultMax;
+  };
+
+  this.$get = () => this.config;
+}

--- a/src/ng-currency.directive.js
+++ b/src/ng-currency.directive.js
@@ -1,11 +1,16 @@
 /* @ngInject */
-export default function ngCurrency($filter, $locale) {
+export default function ngCurrency($filter, $locale, ngCurrencySettings) {
   return {
     require: 'ngModel',
     link: (scope, element, attrs, controller) => {
-      let hardCap, min, max, currencySymbol, ngRequired;
       let active = true;
-      let fraction = 2;
+      let currencySymbol, ngRequired;
+      let {
+        defaultHardCap: hardCap,
+        defaultMin: min,
+        defaultMax: max,
+        defaultFraction: fraction
+      } = ngCurrencySettings;
 
       attrs.$observe('ngCurrency', (value) => {
         active = (value !== 'false');
@@ -187,7 +192,15 @@ export default function ngCurrency($filter, $locale) {
       }
 
       function getCurrencySymbol() {
-        return currencySymbol === undefined ? $locale.NUMBER_FORMATS.CURRENCY_SYM : currencySymbol;
+        if (currencySymbol !== undefined) {
+          return currencySymbol;
+        }
+
+        if (ngCurrencySettings.defaultCurrencySymbol !== undefined) {
+          return ngCurrencySettings.defaultCurrencySymbol;
+        }
+
+        return $locale.NUMBER_FORMATS.CURRENCY_SYM;
       }
     }
   };

--- a/src/ng-currency.module.js
+++ b/src/ng-currency.module.js
@@ -1,8 +1,10 @@
 import angular from 'angular';
 import ngCurrency from './ng-currency.directive.js';
+import ngCurrencySettings from './ng-currency-settings.provider.js';
 
 const module = angular.module('ng-currency', []);
 
 module.directive('ngCurrency', ngCurrency);
+module.provider('ngCurrencySettings', ngCurrencySettings);
 
 export default module.name;

--- a/test/ng-currency/ng-currency-settings.provider.spec.js
+++ b/test/ng-currency/ng-currency-settings.provider.spec.js
@@ -1,0 +1,63 @@
+import ngCurrency from '../../src/ng-currency.module.js';
+import defaults from './templates/defaults.html';
+
+describe('ngCurrencySettings tests', () => {
+  it('fraction should be applied', () => {
+    const { element, scope } = initWithConfigAndCompile({ defaultFraction: 1 });
+
+    scope.value = 123.451;
+    scope.$digest();
+    expect(element.val()).toEqual('$123.5');
+  });
+
+  it('currencySymbol should be applied', () => {
+    const { element, scope } = initWithConfigAndCompile({ defaultCurrencySymbol: 'CHF' });
+
+    scope.value = 123;
+    scope.$digest();
+    expect(element.val()).toEqual('CHF123.00');
+  });
+
+  it('min should be applied', () => {
+    const { element, scope } = initWithConfigAndCompile({ defaultMin: 1 });
+
+    scope.value = 0.01;
+    scope.$digest();
+    expect(element.hasClass('ng-invalid-min')).toBeTruthy();
+    expect(element.val()).toEqual('$0.01');
+    element.triggerHandler('focus');
+    expect(element.val()).toEqual('0.01');
+    element.triggerHandler('blur');
+    expect(element.val()).toEqual('$0.01');
+  });
+
+  it('max should be applied', () => {
+    const { element, scope } = initWithConfigAndCompile({ defaultMax: 1 });
+
+    scope.value = 2;
+    scope.$digest();
+    expect(element.hasClass('ng-invalid-max')).toBeTruthy();
+    expect(element.val()).toEqual('$2.00');
+    element.triggerHandler('focus');
+    expect(element.val()).toEqual('2');
+    element.triggerHandler('blur');
+    expect(element.val()).toEqual('$2.00');
+  });
+});
+
+function initWithConfigAndCompile(config) {
+  let element, scope;
+
+  angular.mock.module(ngCurrency, { ngCurrencySettings: config});
+
+  angular.mock.inject(($rootScope, $compile, $timeout) => {
+    scope = $rootScope.$new();
+    scope.value = 0;
+    scope.$digest();
+    element = $compile(defaults)(scope);
+    element = element.find('input');
+    $timeout.flush();
+  });
+
+  return { element, scope };
+}


### PR DESCRIPTION
I had to define the same currency symbol for each input field. This is why I created a settings provider to provide the ability to define the currency symbol (and every other property) in one place.