### PR TITLE
fix(ngModelOptions): values should be reflected to the model with updateOn blur (Angular 1.6.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "angular": "1.5.8",
-    "angular-mocks": "1.5.8",
+    "angular": "1.6.0",
+    "angular-mocks": "1.6.0",
     "babel-core": "6.11.4",
     "babel-loader": "6.2.4",
     "babel-preset-es2015": "6.9.0",

--- a/src/ng-currency.directive.js
+++ b/src/ng-currency.directive.js
@@ -83,7 +83,14 @@ export default function ngCurrency($filter, $locale) {
       function reformat() {
         if (active) {
           let value;
-          if (controller.$options && controller.$options.updateOn === 'blur') {
+          let updateOn;
+          if (controller.$options) {
+            // HACK(nick-woodward): this is to maintain backwards compatability with Angular 1.5.9 and lower.
+            // TODO(nick-woodward): This should be removed when ngCurrency does a 2.0.0 release
+            // Reference: https://github.com/angular/angular.js/commit/296cfce40c25e9438bfa46a0eb27240707a10ffa
+            updateOn = controller.$options.getOption ? controller.$options.getOption('updateOn') : controller.$options.updateOn;
+          }
+          if (updateOn === 'blur') {
             value = controller.$viewValue;
             for (let i = controller.$parsers.length - 1; i >= 0; i--) {
               value = controller.$parsers[i](value);


### PR DESCRIPTION
Angular 1.6.0 introduced quite a few breaking changes one of them being a break to the ngModelOptions API.

This PR should address the issue while maintaining backwards compatibility with Angular 1.5.9 and lower.

### References

https://github.com/angular/angular.js/commit/296cfce40c25e9438bfa46a0eb27240707a10ffa

### Related Issues

closes #125 