### PR TITLE
Add autoFill and highlightOnFocus as directive options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Main features:
 * Enable/disable formatter using ng-currency={{var}}
 * Optional fraction places value. The default remains 2 decimal places.
 * You can redraw all directives broadcasting "currencyRedraw" event.
-* Enable/Disable show zeroes using display-zeroes 'true' or 'false'
+* Pre-populate the field with zeros using auto-fill="true"
 * Not isolated scope. It plays well with others directives!
 
 ## npm

--- a/src/ng-currency-settings.provider.js
+++ b/src/ng-currency-settings.provider.js
@@ -5,7 +5,9 @@ export default class ngCurrencySettings {
         hardCap: false,
         min: undefined,
         max: undefined,
-        currencySymbol: undefined
+        currencySymbol: undefined,
+        autoFill: false,
+        highlightOnFocus: false
       };
     }
 

--- a/src/ng-currency-settings.provider.js
+++ b/src/ng-currency-settings.provider.js
@@ -7,7 +7,7 @@ export default class ngCurrencySettings {
         max: undefined,
         currencySymbol: undefined,
         autoFill: false,
-        highlightOnFocus: false
+        highlightOnFocus: true
       };
     }
 

--- a/src/ng-currency.directive.js
+++ b/src/ng-currency.directive.js
@@ -165,8 +165,9 @@ export default function ngCurrency($filter, $locale, $timeout, ngCurrencySetting
             controller.$render();
             element.triggerHandler('focus');
           }
+
           if (highlightOnFocus) {
-            element.select();
+            element[0].select(); // use HTMLInputElement to highlight text
           }
         }
       });

--- a/src/ng-currency.directive.js
+++ b/src/ng-currency.directive.js
@@ -162,15 +162,18 @@ export default function ngCurrency($filter, $locale, $timeout, ngCurrencySetting
 
           let rawValue = controller.$$rawModelValue;
           let isRawValueDefined = [undefined, null, ''].indexOf(rawValue) === -1;
+          let doCommit = false;
           if (autoFill === 'focus' && !isRawValueDefined) {
             rawValue = 0;
             isRawValueDefined = true;
+            doCommit = true; // by not committing, we end up with blur not working for autofill.
           }
           const value = isRawValueDefined ? $filter('number')(rawValue, fraction).replace(groupRegex, '') : rawValue;
 
           if (controller.$viewValue !== value) {
             controller.$viewValue = value;
             controller.$render();
+            if (doCommit) controller.$commitViewValue(); // only commit value if we actually need to
             element.triggerHandler('focus');
           }
 

--- a/src/ng-currency.directive.js
+++ b/src/ng-currency.directive.js
@@ -161,7 +161,7 @@ export default function ngCurrency($filter, $locale, $timeout, ngCurrencySetting
           const groupRegex = new RegExp(`\\${$locale.NUMBER_FORMATS.GROUP_SEP}`, 'g');
 
           let rawValue = controller.$$rawModelValue;
-          let isRawValueDefined = [undefined, null, ''].indexOf(rawValue) !== -1;
+          let isRawValueDefined = [undefined, null, ''].indexOf(rawValue) === -1;
           if (autoFill === 'focus' && !isRawValueDefined) {
             rawValue = 0;
             isRawValueDefined = true;

--- a/src/ng-currency.directive.js
+++ b/src/ng-currency.directive.js
@@ -42,7 +42,6 @@ export default function ngCurrency($filter, $locale, $timeout, ngCurrencySetting
       });
       attrs.$observe('autoFill', (value) => {
         autoFill = value == 'true'; // convert string -> boolean
-        reformat();
         revalidate();
       });
       attrs.$observe('highlightOnFocus', (value) => {

--- a/src/ng-currency.directive.js
+++ b/src/ng-currency.directive.js
@@ -43,6 +43,7 @@ export default function ngCurrency($filter, $locale, $timeout, ngCurrencySetting
       attrs.$observe('autoFill', (value) => {
         autoFill = value == 'true'; // convert string -> boolean
         reformat();
+        revalidate();
       });
       attrs.$observe('highlightOnFocus', (value) => {
         highlightOnFocus = value == 'true'; // convert string -> boolean
@@ -127,6 +128,10 @@ export default function ngCurrency($filter, $locale, $timeout, ngCurrencySetting
       function revalidate() {
         controller.$validate();
         if (active) {
+          if (autoFill && [undefined, null, ''].indexOf(controller.$$rawModelValue) !== -1) {
+            controller.$$rawModelValue = '0';
+          }
+
           const value = keepInRange(controller.$$rawModelValue);
           if (value !== controller.$$rawModelValue) {
             controller.$setViewValue(value.toFixed(fraction));
@@ -154,10 +159,6 @@ export default function ngCurrency($filter, $locale, $timeout, ngCurrencySetting
 
       element.bind('focus', () => {
         if (active) {
-          if (autoFill && [undefined, null, ''].indexOf(controller.$$rawModelValue) !== -1) {
-            controller.$$rawModelValue = '0';
-          }
-
           const groupRegex = new RegExp(`\\${$locale.NUMBER_FORMATS.GROUP_SEP}`, 'g');
           const value = [undefined, null, ''].indexOf(controller.$$rawModelValue) === -1 ? $filter('number')(controller.$$rawModelValue, fraction).replace(groupRegex, '') : controller.$$rawModelValue;
           if (controller.$viewValue !== value) {

--- a/test/ng-currency/ng-currency-settings.provider.spec.js
+++ b/test/ng-currency/ng-currency-settings.provider.spec.js
@@ -20,7 +20,7 @@ describe('provider(ngCurrencySettings)', () => {
         max: undefined,
         currencySymbol: undefined,
         autoFill: false,
-        highlightOnFocus: false
+        highlightOnFocus: true
       });
     });
   });
@@ -34,7 +34,7 @@ describe('provider(ngCurrencySettings)', () => {
         max: undefined,
         currencySymbol: undefined,
         autoFill: false,
-        highlightOnFocus: false
+        highlightOnFocus: true
       });
 
       ngCurrencySettingsProvider.defaults = true;
@@ -61,7 +61,7 @@ describe('provider(ngCurrencySettings)', () => {
           max: undefined,
           currencySymbol: undefined,
           autoFill: false,
-          highlightOnFocus: false
+          highlightOnFocus: true
         });
       });
 

--- a/test/ng-currency/ng-currency-settings.provider.spec.js
+++ b/test/ng-currency/ng-currency-settings.provider.spec.js
@@ -18,7 +18,9 @@ describe('provider(ngCurrencySettings)', () => {
         hardCap: false,
         min: undefined,
         max: undefined,
-        currencySymbol: undefined
+        currencySymbol: undefined,
+        autoFill: false,
+        highlightOnFocus: false
       });
     });
   });
@@ -30,7 +32,9 @@ describe('provider(ngCurrencySettings)', () => {
         hardCap: false,
         min: undefined,
         max: undefined,
-        currencySymbol: undefined
+        currencySymbol: undefined,
+        autoFill: false,
+        highlightOnFocus: false
       });
 
       ngCurrencySettingsProvider.defaults = true;
@@ -55,7 +59,9 @@ describe('provider(ngCurrencySettings)', () => {
           hardCap: false,
           min: undefined,
           max: undefined,
-          currencySymbol: undefined
+          currencySymbol: undefined,
+          autoFill: false,
+          highlightOnFocus: false
         });
       });
 

--- a/test/ng-currency/ng-currency.directive.spec.js
+++ b/test/ng-currency/ng-currency.directive.spec.js
@@ -768,22 +768,27 @@ describe('ngCurrency directive tests', () => {
         scope.autoFill = true;
         scope.$digest();
         expect(element.val()).toEqual('$0.00');
+        expect(scope.value).toEqual(0);
       });
       it('should not override a predefined value', () => {
         scope.autoFill = true;
         scope.value = 22;
         scope.$digest();
         expect(element.val()).toEqual('$22.00');
+        expect(scope.value).toEqual(22);
       });
       it('should only autofill on focus if set', () => {
         scope.autoFill = 'focus';
         scope.$digest();
         expect(element.val()).toEqual('');
+        expect(scope.value).toBeFalsy(); // undefined, null, empty string
         element.triggerHandler('focus');
         expect(element.val()).toEqual('0.00');
+        expect(scope.value).toEqual(0);
       });
       it('should not autofill when not asked to', () => {
         expect(element.val()).toEqual('');
+        expect(scope.value).toBeFalsy(); // undefined, null, empty string
       });
     });
 

--- a/test/ng-currency/ng-currency.directive.spec.js
+++ b/test/ng-currency/ng-currency.directive.spec.js
@@ -756,6 +756,14 @@ describe('ngCurrency directive tests', () => {
     });
 
     describe('AutoFill', () => {
+      beforeEach(angular.mock.inject(($rootScope, $compile, $timeout) => {
+        scope = $rootScope.$new();
+        scope.value = undefined; // force undefined value
+        scope.autoFill = false;
+        scope.$digest();
+        element = $compile(`<input class="currency-input" ng-currency ng-model="value" auto-fill="{{autoFill}}"">`)(scope);
+        $timeout.flush();
+      }));
       it('should populate the field with zero', () => {
         scope.autoFill = true;
         scope.$digest();
@@ -767,20 +775,15 @@ describe('ngCurrency directive tests', () => {
         scope.$digest();
         expect(element.val()).toEqual('$22.00');
       });
-
-      describe('AutoFill (disabled)', () => {
-        // We need to specify this so we can actually test what happens with autofill, as the default
-        // setup will cause the field to autofill before we can disable it.
-        beforeEach(angular.mock.inject(($rootScope, $compile, $timeout) => {
-          scope.autoFill = false;
-          scope.value = undefined; // force undefined value
-          scope.$digest();
-          element = $compile(`<input class="currency-input" ng-currency ng-model="value" auto-fill="{{autoFill}}">`)(scope);
-          $timeout.flush();
-        }));
-        it('should not autofill when not asked to', () => {
-          expect(element.val()).toEqual('');
-        });
+      it('should only autofill on focus if set', () => {
+        scope.autoFill = 'focus';
+        scope.$digest();
+        expect(element.val()).toEqual('');
+        element.triggerHandler('focus');
+        expect(element.val()).toEqual('0.00');
+      });
+      it('should not autofill when not asked to', () => {
+        expect(element.val()).toEqual('');
       });
     });
 

--- a/test/ng-currency/ng-currency.directive.spec.js
+++ b/test/ng-currency/ng-currency.directive.spec.js
@@ -760,8 +760,10 @@ describe('ngCurrency directive tests', () => {
         scope = $rootScope.$new();
         scope.value = undefined; // force undefined value
         scope.autoFill = false;
+        scope.min = undefined;
+        scope.max = undefined;
         scope.$digest();
-        element = $compile(`<input class="currency-input" ng-currency ng-model="value" auto-fill="{{autoFill}}"">`)(scope);
+        element = $compile(`<input class="currency-input" ng-currency ng-model="value" auto-fill="{{autoFill}}" min="{{min}}" max="{{max}}"">`)(scope);
         $timeout.flush();
       }));
       it('should populate the field with zero', () => {
@@ -776,6 +778,20 @@ describe('ngCurrency directive tests', () => {
         scope.$digest();
         expect(element.val()).toEqual('$22.00');
         expect(scope.value).toEqual(22);
+      });
+      it('should not override a minimum higher than zero', () => {
+        scope.autoFill = true;
+        scope.min = 10;
+        scope.$digest();
+        expect(element.val()).toEqual('$10.00');
+        expect(scope.value).toEqual(10);
+      });
+      it('should not override a maximum lower than zero', () => {
+        scope.autoFill = true;
+        scope.max = -10;
+        scope.$digest();
+        expect(element.val()).toEqual('-$10.00');
+        expect(scope.value).toEqual(-10);
       });
       it('should only autofill on focus if set', () => {
         scope.autoFill = 'focus';

--- a/test/ng-currency/ng-currency.directive.spec.js
+++ b/test/ng-currency/ng-currency.directive.spec.js
@@ -753,6 +753,20 @@ describe('ngCurrency directive tests', () => {
       });
     });
 
+    describe('AutoFill', () => {
+      it('should populate the field with zero', () => {
+        scope.autoFill = true;
+        scope.$digest();
+        expect(element.val()).toEqual('$0.00');
+      });
+      it('should not override a predefined value', () => {
+        scope.autoFill = true;
+        scope.value = 22;
+        scope.$digest();
+        expect(element.val()).toEqual('$22.00');
+      });
+    });
+
     describe('$pristine', () => {
       it('should be pristine when initialized with a custom currencySymbol', () => {
         scope.currencySymbol = '¥';

--- a/test/ng-currency/ng-currency.directive.spec.js
+++ b/test/ng-currency/ng-currency.directive.spec.js
@@ -345,6 +345,8 @@ describe('ngCurrency directive tests', () => {
       scope.modelOptions = {};
       scope.currencySymbol = '$';
       scope.required = true;
+      scope.autoFill = false;
+      scope.highlightOnFocus = true;
       scope.$digest();
       element = $compile(variables)(scope);
       element = element.find('input');
@@ -765,16 +767,38 @@ describe('ngCurrency directive tests', () => {
         scope.$digest();
         expect(element.val()).toEqual('$22.00');
       });
-    });
 
-    describe('HighlightOnFocus', () => {
-      it('should highlight the entire field when focused', () => {
-        // TODO(travis ralston): Focus element to make this test pass
-        expect(element.val()).toEqual('0.00');
-        expect(element[0].selectionStart).toEqual(0);
-        expect(element[0].selectionStart).toEqual(4);
+      describe('AutoFill (disabled)', () => {
+        // We need to specify this so we can actually test what happens with autofill, as the default
+        // setup will cause the field to autofill before we can disable it.
+        beforeEach(angular.mock.inject(($rootScope, $compile, $timeout) => {
+          scope.autoFill = false;
+          scope.value = undefined; // force undefined value
+          scope.$digest();
+          element = $compile(`<input class="currency-input" ng-currency ng-model="value" auto-fill="{{autoFill}}">`)(scope);
+          $timeout.flush();
+        }));
+        it('should not autofill when not asked to', () => {
+          expect(element.val()).toEqual('');
+        });
       });
     });
+
+    // Tests disabled because of https://github.com/ariya/phantomjs/issues/12493
+    // describe('HighlightOnFocus', () => {
+    //   it('should highlight the entire field when focused', () => {
+    //     element.triggerHandler('focus');
+    //     expect(element[0].selectionStart).toEqual(0);
+    //     expect(element[0].selectionEnd).toEqual(5);
+    //   });
+    //   it('should not highlight when the option is disabled', () => {
+    //     scope.highlightOnFocus = false;
+    //     scope.$digest();
+    //     element.triggerHandler('focus');
+    //     expect(element[0].selectionStart).toEqual(5);
+    //     expect(element[0].selectionEnd).toEqual(5);
+    //   });
+    // });
 
     describe('$pristine', () => {
       it('should be pristine when initialized with a custom currencySymbol', () => {

--- a/test/ng-currency/ng-currency.directive.spec.js
+++ b/test/ng-currency/ng-currency.directive.spec.js
@@ -803,7 +803,7 @@ describe('ngCurrency directive tests', () => {
         expect(scope.value).toBeFalsy(); // undefined, null, empty string
         element.triggerHandler('focus');
         expect(element.val()).toEqual('0.00');
-        expect(scope.value).toEqual(0);
+        expect(scope.value).toBeFalsy(); // value not committed, should be falsey still
       });
       it('should not autofill when not asked to', () => {
         expect(element.val()).toEqual('');

--- a/test/ng-currency/ng-currency.directive.spec.js
+++ b/test/ng-currency/ng-currency.directive.spec.js
@@ -804,6 +804,9 @@ describe('ngCurrency directive tests', () => {
         element.triggerHandler('focus');
         expect(element.val()).toEqual('0.00');
         expect(scope.value).toBeFalsy(); // value not committed, should be falsey still
+        element.triggerHandler('blur');
+        expect(element.val()).toEqual('$0.00');
+        expect(scope.value).toEqual(0);
       });
       it('should not autofill when not asked to', () => {
         expect(element.val()).toEqual('');

--- a/test/ng-currency/ng-currency.directive.spec.js
+++ b/test/ng-currency/ng-currency.directive.spec.js
@@ -767,6 +767,15 @@ describe('ngCurrency directive tests', () => {
       });
     });
 
+    describe('HighlightOnFocus', () => {
+      it('should highlight the entire field when focused', () => {
+        // TODO(travis ralston): Focus element to make this test pass
+        expect(element.val()).toEqual('0.00');
+        expect(element[0].selectionStart).toEqual(0);
+        expect(element[0].selectionStart).toEqual(4);
+      });
+    });
+
     describe('$pristine', () => {
       it('should be pristine when initialized with a custom currencySymbol', () => {
         scope.currencySymbol = '¥';

--- a/test/ng-currency/ng-currency.directive.spec.js
+++ b/test/ng-currency/ng-currency.directive.spec.js
@@ -762,8 +762,9 @@ describe('ngCurrency directive tests', () => {
         scope.autoFill = false;
         scope.min = undefined;
         scope.max = undefined;
+        scope.hardCap = true;
         scope.$digest();
-        element = $compile(`<input class="currency-input" ng-currency ng-model="value" auto-fill="{{autoFill}}" min="{{min}}" max="{{max}}"">`)(scope);
+        element = $compile(`<input class="currency-input" ng-currency ng-model="value" auto-fill="{{autoFill}}" min="{{min}}" max="{{max}}" hard-cap="{{hardCap}}">`)(scope);
         $timeout.flush();
       }));
       it('should populate the field with zero', () => {
@@ -782,6 +783,7 @@ describe('ngCurrency directive tests', () => {
       it('should not override a minimum higher than zero', () => {
         scope.autoFill = true;
         scope.min = 10;
+        scope.hardCap = true;
         scope.$digest();
         expect(element.val()).toEqual('$10.00');
         expect(scope.value).toEqual(10);
@@ -789,6 +791,7 @@ describe('ngCurrency directive tests', () => {
       it('should not override a maximum lower than zero', () => {
         scope.autoFill = true;
         scope.max = -10;
+        scope.hardCap = true;
         scope.$digest();
         expect(element.val()).toEqual('-$10.00');
         expect(scope.value).toEqual(-10);

--- a/test/ng-currency/templates/variables.html
+++ b/test/ng-currency/templates/variables.html
@@ -8,5 +8,7 @@
         max="{{max}}"
         fraction="{{fraction}}"
         currency-symbol="{{currencySymbol}}"
-        hard-cap="{{hardCap}}"/>
+        hard-cap="{{hardCap}}"
+        highlight-on-focus="{{highlightOnFocus}}"
+        auto-fill="{{autoFill}}" />
 </form>

--- a/test/ng-currency/templates/variables.html
+++ b/test/ng-currency/templates/variables.html
@@ -10,5 +10,6 @@
         currency-symbol="{{currencySymbol}}"
         hard-cap="{{hardCap}}"
         highlight-on-focus="{{highlightOnFocus}}"
-        auto-fill="{{autoFill}}" />
+        auto-fill="{{autoFill}}"
+        auto-fill-on-focus="{{autoFillOnFocus}}" />
 </form>


### PR DESCRIPTION
The readme claims that displayZeros is supported, but does not work. This adds a useful alternative to displayZeros through two options: autoFill and highlightOnFocus.

autoFill simply populates the field with `0` if there has been no number entered. This is done before formatting takes place just in case something needs to happen (such as the result being `0.00`). This also occurs before the minimum is considered, so that the minimum can be applied to autoFill.

highlightOnFocus addresses #118 and is enabled by default. This is to make entering a large number of fields easier for the user, and just generally make the field more usable.