### PR TITLE
chore: upgrade `remove-lockfiles` to v2.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ bower_components/
 dist/
 coverage/
 npm-debug.log
-package-lock.json

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "nps": "^5.7.1",
     "phantomjs-prebuilt": "^2.1.8",
     "publish-latest": "^1.1.2",
-    "remove-lockfiles": "^1.4.2",
+    "remove-lockfiles": "^2.0.4",
     "semantic-release": "^11.0.0",
     "sinon": "^4.0.0",
     "webpack": "^3.0.0",


### PR DESCRIPTION
[remove-lockfiles](https://github.com/luftywiranda13/remove-lockfiles) v2.x comes with a lot of improvements especially in performance and the business logic of how it forces removing lockfiles from a repo.

But nothing's changed in terms of how to use it.

The only breaking change introduced in v2 is it requires node 6+

Closes #160 